### PR TITLE
Add CV download link to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,8 @@
             <a href="mailto:202200101041@stumail.sztu.edu.cn">202200101041@stumail.sztu.edu.cn</a> |
             <a href="mailto:dinghaokai@mails.x-institute.edu.cn">dinghaokai@mails.x-institute.edu.cn</a><br>
             <a href="https://scholar.google.com/citations?user=ikir1CUAAAAJ&hl=en" target="_blank" rel="noopener noreferrer">Google Scholar</a> |
-            <a href="https://orcid.org/0009-0001-6158-9897" target="_blank" rel="noopener noreferrer">ORCID</a>
+            <a href="https://orcid.org/0009-0001-6158-9897" target="_blank" rel="noopener noreferrer">ORCID</a> |
+            <a href="pdfs/HaokaiDing_CV_EN.pdf" target="_blank" rel="noopener noreferrer"><span class="lang-en">Download CV</span><span class="lang-zh">下载简历</span></a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add bilingual "Download CV" link on homepage pointing to existing PDF

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c036c94dac832fa67cb7f7d195f06b