### PR TITLE
Link ASME competition finalist award to official page

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
         <h3><span class="lang-en">Provincial-Level & Above</span><span class="lang-zh">省级及以上</span></h3>
         <div class="awards-list">
           <div class="award-item">
-            <span class="award-name"><span class="lang-en">Finalist, ASME Student Mechanism & Robot Design Competition</span><span class="lang-zh">ASME 学生机械与机器人设计竞赛决赛入围</span></span>
+            <span class="award-name"><a href="https://sites.google.com/site/asmemrc/design-competition-showcase/2025-finalists#h.2oibi1g704mf" target="_blank" rel="noopener noreferrer"><span class="lang-en">Finalist, ASME Student Mechanism & Robot Design Competition</span><span class="lang-zh">ASME 学生机械与机器人设计竞赛决赛入围</span></a></span>
             <span class="award-year">2025</span>
           </div>
           <div class="award-item">


### PR DESCRIPTION
## Summary
- Link the "ASME Student Mechanism & Robot Design Competition" finalist award to the official finalists page for easier reference.

## Testing
- `npm test` *(fails: could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c042a20280832faa6eb7f8c0bc58d5