### PR TITLE
style: highlight CV download link

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,8 +55,10 @@
             <a href="mailto:202200101041@stumail.sztu.edu.cn">202200101041@stumail.sztu.edu.cn</a> |
             <a href="mailto:dinghaokai@mails.x-institute.edu.cn">dinghaokai@mails.x-institute.edu.cn</a><br>
             <a href="https://scholar.google.com/citations?user=ikir1CUAAAAJ&hl=en" target="_blank" rel="noopener noreferrer">Google Scholar</a> |
-            <a href="https://orcid.org/0009-0001-6158-9897" target="_blank" rel="noopener noreferrer">ORCID</a> |
-            <a href="pdfs/HaokaiDing_CV_EN.pdf" target="_blank" rel="noopener noreferrer"><span class="lang-en">Download CV</span><span class="lang-zh">下载简历</span></a>
+            <a href="https://orcid.org/0009-0001-6158-9897" target="_blank" rel="noopener noreferrer">ORCID</a><br>
+            <a class="download-cv" href="pdfs/HaokaiDing_CV_EN.pdf" target="_blank" rel="noopener noreferrer">
+              <span class="lang-en">📄 Download CV</span><span class="lang-zh">📄 下载简历</span>
+            </a>
           </p>
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -31,6 +31,12 @@
     .contact-info p{margin:0;line-height:1.5;font-size:.95em;color:#444}
     .contact-info a{color:var(--brand);text-decoration:none}
     .contact-info a:hover{text-decoration:underline}
+    .download-cv{
+      display:inline-block;margin-top:8px;padding:6px 12px;
+      background:var(--brand);color:#fff!important;border-radius:6px;
+      font-family:'Lato',sans-serif;font-weight:700;text-decoration:none
+    }
+    .download-cv:hover{background:#094a99;text-decoration:none}
 
     .profile-container{position:relative;width:120px;height:120px;margin-right:30px;border-radius:10px;overflow:hidden;flex-shrink:0}
     .profile-image{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;border-radius:10px;transition:opacity .4s ease}


### PR DESCRIPTION
## Summary
- add an icon-styled button for downloading the CV on a new line
- style the new CV button with branding and hover effects for better visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0489f9fb0832fb8abcf90d16ec760