### PR TITLE
refine nav layout and CV button positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,11 +55,13 @@
             <a href="mailto:202200101041@stumail.sztu.edu.cn">202200101041@stumail.sztu.edu.cn</a> |
             <a href="mailto:dinghaokai@mails.x-institute.edu.cn">dinghaokai@mails.x-institute.edu.cn</a><br>
             <a href="https://scholar.google.com/citations?user=ikir1CUAAAAJ&hl=en" target="_blank" rel="noopener noreferrer">Google Scholar</a> |
-            <a href="https://orcid.org/0009-0001-6158-9897" target="_blank" rel="noopener noreferrer">ORCID</a><br>
-            <a class="download-cv" href="pdfs/HaokaiDing_CV_EN.pdf" target="_blank" rel="noopener noreferrer">
-              <span class="lang-en">📄 Download CV</span><span class="lang-zh">📄 下载简历</span>
-            </a>
+            <a href="https://orcid.org/0009-0001-6158-9897" target="_blank" rel="noopener noreferrer">ORCID</a>
           </p>
+        </div>
+        <div class="cv-button">
+          <a class="download-cv" href="pdfs/HaokaiDing_CV_EN.pdf" target="_blank" rel="noopener noreferrer">
+            <span class="lang-en">📄 Download CV</span><span class="lang-zh">📄 下载简历</span>
+          </a>
         </div>
       </div>
     </header>

--- a/styles.css
+++ b/styles.css
@@ -21,8 +21,14 @@
     #lang-switcher a.active{color:var(--brand);background:#e7f1ff}
 
     /* 导航 */
-    nav.site-nav{background:#f5f5f5;padding:10px 12px;border-radius:12px;margin-bottom:16px;display:flex;gap:12px;flex-wrap:wrap}
-    nav.site-nav a{text-decoration:none;font-family:'Lato',sans-serif;font-weight:700;color:var(--brand);padding:8px 12px;border-radius:999px;background:#fff;border:1px solid #e7f1ff}
+    nav.site-nav{
+      background:#f5f5f5;padding:10px 12px;border-radius:12px;margin-bottom:16px;
+      display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:12px;
+    }
+    nav.site-nav a{
+      text-decoration:none;font-family:'Lato',sans-serif;font-weight:700;color:var(--brand);
+      padding:8px 12px;border-radius:999px;background:#fff;border:1px solid #e7f1ff;text-align:center;
+    }
     nav.site-nav a:hover{background:#e7f1ff}
 
     /* 头部/头像 */
@@ -31,8 +37,10 @@
     .contact-info p{margin:0;line-height:1.5;font-size:.95em;color:#444}
     .contact-info a{color:var(--brand);text-decoration:none}
     .contact-info a:hover{text-decoration:underline}
+    .header-info{display:flex;flex-direction:column}
+    .cv-button{margin-top:12px;align-self:flex-start}
     .download-cv{
-      display:inline-block;margin-top:8px;padding:6px 12px;
+      display:inline-block;padding:6px 12px;
       background:var(--brand);color:#fff!important;border-radius:6px;
       font-family:'Lato',sans-serif;font-weight:700;text-decoration:none
     }


### PR DESCRIPTION
## Summary
- switch navigation to a grid layout for even spacing across four sections
- move CV download button into its own block under contact info for better visual flow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c04b0e202c832fb3c52a8f8ab19b63