### PR TITLE
fix: adjust profile photo aspect ratio

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -46,8 +46,8 @@
     }
     .download-cv:hover{background:#094a99;text-decoration:none}
 
-    .profile-container{position:relative;width:120px;height:120px;margin-right:30px;border-radius:10px;overflow:hidden;flex-shrink:0}
-    .profile-image{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;border-radius:10px;transition:opacity .4s ease}
+    .profile-container{position:relative;width:120px;aspect-ratio:2/3;margin-right:30px;border-radius:10px;overflow:hidden;flex-shrink:0;box-shadow:0 0 8px rgba(0,0,0,.1)}
+    .profile-image{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;object-position:center;border-radius:10px;transition:opacity .4s ease}
     .profile-image.default{opacity:1}.profile-image.hover{opacity:0}
     .profile-container:hover .profile-image.default,.profile-container.toggled .profile-image.default{opacity:0}
     .profile-container:hover .profile-image.hover,.profile-container.toggled .profile-image.hover{opacity:1}


### PR DESCRIPTION
## Summary
- ensure profile image uses a 2:3 aspect ratio instead of a fixed square
- center image positioning and add subtle shadow for a cleaner look

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c04c80d0a0832f978c5a7633e9db83