### PR TITLE
Link awards and move CV button

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,9 @@
         <a href="#" data-lang="en" class="lang-link active">English</a> /
         <a href="#" data-lang="zh" class="lang-link">中文</a>
       </div>
+      <a class="download-cv" href="pdfs/HaokaiDing_CV_EN.pdf" target="_blank" rel="noopener noreferrer">
+        <span class="lang-en">📄 Download CV</span><span class="lang-zh">📄 下载简历</span>
+      </a>
     </div>
 
     <nav class="site-nav" aria-label="Section navigation">
@@ -57,11 +60,6 @@
             <a href="https://scholar.google.com/citations?user=ikir1CUAAAAJ&hl=en" target="_blank" rel="noopener noreferrer">Google Scholar</a> |
             <a href="https://orcid.org/0009-0001-6158-9897" target="_blank" rel="noopener noreferrer">ORCID</a>
           </p>
-        </div>
-        <div class="cv-button">
-          <a class="download-cv" href="pdfs/HaokaiDing_CV_EN.pdf" target="_blank" rel="noopener noreferrer">
-            <span class="lang-en">📄 Download CV</span><span class="lang-zh">📄 下载简历</span>
-          </a>
         </div>
       </div>
     </header>
@@ -234,11 +232,11 @@
             <span class="award-year">2025</span>
           </div>
           <div class="award-item">
-            <span class="award-name"><span class="lang-en">Gold Prize, The 9th China "Internet+" Innovation Competition (Guangdong Division)</span><span class="lang-zh">第九届中国国际“互联网+”大学生创新创业大赛 (广东省分赛金奖)</span></span>
+            <span class="award-name"><a href="https://cy.ncss.cn/" target="_blank" rel="noopener noreferrer"><span class="lang-en">Gold Prize, The 9th China "Internet+" Innovation Competition (Guangdong Division)</span><span class="lang-zh">第九届中国国际“互联网+”大学生创新创业大赛 (广东省分赛金奖)</span></a></span>
             <span class="award-year">2023</span>
           </div>
           <div class="award-item">
-            <span class="award-name"><span class="lang-en">Second Prize, The 17th "Challenge Cup" Extracurricular Science Competition (Guangdong Division)</span><span class="lang-zh">第十七届“挑战杯”全国大学生课外学术科技作品竞赛 (广东省分赛二等奖)</span></span>
+            <span class="award-name"><a href="https://www.tiaozhanbei.net/" target="_blank" rel="noopener noreferrer"><span class="lang-en">Second Prize, The 17th "Challenge Cup" Extracurricular Science Competition (Guangdong Division)</span><span class="lang-zh">第十七届“挑战杯”全国大学生课外学术科技作品竞赛 (广东省分赛二等奖)</span></a></span>
             <span class="award-year">2023</span>
           </div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -39,7 +39,6 @@
     .contact-info a{color:var(--brand);text-decoration:none}
     .contact-info a:hover{text-decoration:underline}
     .header-info{display:flex;flex-direction:column}
-    .cv-button{margin-top:12px;align-self:flex-start}
     .download-cv{
       display:inline-block;padding:6px 12px;
       background:var(--brand);color:#fff!important;border-radius:6px;


### PR DESCRIPTION
## Summary
- Link Internet+ and Challenge Cup awards to their official competition sites.
- Relocate the CV download button to the page's top-right controls and tidy unused styling.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c04fab8e58832fb721e51201ee9abe