### PR TITLE
Add SPIDAPT video modal and button

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,9 @@
       <a class="download-cv" href="pdfs/HaokaiDing_CV_EN.pdf" target="_blank" rel="noopener noreferrer">
         <span class="lang-en">📄 Download CV</span><span class="lang-zh">📄 下载简历</span>
       </a>
+      <button class="watch-video" id="videoButton" type="button">
+        <span class="lang-en">🎥 SPIDAPT Demo</span><span class="lang-zh">🎥 SPIDAPT演示</span>
+      </button>
     </div>
 
     <nav class="site-nav" aria-label="Section navigation">
@@ -255,6 +258,14 @@
     <footer>
       <p>&copy; 2025 Haokai Ding · Last updated 2025-09-09</p>
     </footer>
+  </div>
+
+  <!-- 视频弹窗 -->
+  <div id="videoModal" class="video-modal" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="video-modal-content">
+      <button class="close-button" id="videoClose" type="button" aria-label="Close video">&times;</button>
+      <video id="videoPlayer" src="vedios/SPIDAPT.mp4" controls></video>
+    </div>
   </div>
 
   <!-- 论文 PDF 预览弹窗（保留） -->

--- a/scripts.js
+++ b/scripts.js
@@ -24,6 +24,15 @@
     pdfClose.addEventListener('click', closePdfModal);
     document.addEventListener('click',e=>{const t=e.target.closest('.pdf-link');if(!t)return;e.preventDefault();openPdfModal(t.getAttribute('data-pdf'));});
 
+    /* 视频弹窗 */
+    const videoModal=$('#videoModal'), videoPlayer=$('#videoPlayer'), videoClose=$('#videoClose'), videoButton=$('#videoButton');
+    function openVideoModal(){lastFocused=document.activeElement;videoModal.classList.add('open');videoModal.setAttribute('aria-hidden','false');videoPlayer.play();videoClose.focus();}
+    function closeVideoModal(){videoModal.classList.remove('open');videoModal.setAttribute('aria-hidden','true');videoPlayer.pause();videoPlayer.currentTime=0;if(lastFocused&&lastFocused.focus)lastFocused.focus();}
+    videoButton.addEventListener('click',openVideoModal);
+    videoClose.addEventListener('click',closeVideoModal);
+    document.addEventListener('keydown',e=>{ if(e.key==='Escape') closeVideoModal(); });
+    window.addEventListener('click',e=>{ if(e.target===videoModal) closeVideoModal(); });
+
     /* 返回顶部 */
     const backBtn=$('#backToTop');
     const onScroll=()=>{ backBtn.style.display=(window.scrollY>300)?'block':'none'; };

--- a/styles.css
+++ b/styles.css
@@ -39,12 +39,15 @@
     .contact-info a{color:var(--brand);text-decoration:none}
     .contact-info a:hover{text-decoration:underline}
     .header-info{display:flex;flex-direction:column}
-    .download-cv{
+    .download-cv,
+    .watch-video{
       display:inline-block;padding:6px 12px;
       background:var(--brand);color:#fff!important;border-radius:6px;
-      font-family:'Lato',sans-serif;font-weight:700;text-decoration:none
+      font-family:'Lato',sans-serif;font-weight:700;text-decoration:none;
+      border:none;cursor:pointer;
     }
-    .download-cv:hover{background:#094a99;text-decoration:none}
+    .download-cv:hover,
+    .watch-video:hover{background:#094a99;text-decoration:none}
 
     .profile-container{position:relative;width:120px;aspect-ratio:2/3;margin-right:30px;border-radius:10px;overflow:hidden;flex-shrink:0;box-shadow:0 0 8px rgba(0,0,0,.1)}
     .profile-image{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;object-position:center;border-radius:10px;transition:opacity .4s ease}
@@ -134,6 +137,18 @@
     /* 强制语言显示单一 */
     html:not([data-lang="zh"]) .lang-zh{display:none!important}
     html[data-lang="zh"] .lang-en{display:none!important}
+
+    /* 视频弹窗 */
+    .video-modal{
+      position:fixed;inset:0;background:rgba(0,0,0,.7);z-index:1000;
+      opacity:0;visibility:hidden;pointer-events:none;transition:opacity .2s;
+    }
+    .video-modal.open{opacity:1;visibility:visible;pointer-events:auto;}
+    .video-modal-content{
+      position:relative;margin:5% auto;width:60%;max-width:800px;
+      background:#000;border-radius:10px;box-shadow:0 5px 15px rgba(0,0,0,.3);overflow:hidden;
+    }
+    .video-modal-content video{width:100%;height:auto;display:block;}
 
     /* PDF 预览弹窗（用于论文 PDF，保留） */
     .pdf-modal{


### PR DESCRIPTION
## Summary
- Add SPIDAPT Demo button on the homepage top controls
- Implement modal window to play SPIDAPT.mp4 without full-screen takeover
- Style and script modal for smooth open/close interaction

## Testing
- `node --check scripts.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e3234890832fbc38d8645a72cf45