### PR TITLE
Add SPIDAPT video link to IROS paper and sticky navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,7 @@
               <div class="pub-venue">Proceedings of the 2025 IEEE/RSJ International Conference on Intelligent Robots and Systems (IROS)</div>
               <div class="pub-links">
                 <span class="pdf-link" data-pdf="pdfs/IROS25_3633_FI.pdf">[PDF]</span>
+                <span class="video-link" id="videoButton"><span class="lang-en">[Video]</span><span class="lang-zh">[视频]</span></span>
                 <span class="accepted-badge">Accepted</span>
                 <span class="ei-badge">EI</span>
               </div>
@@ -255,6 +256,14 @@
     <footer>
       <p>&copy; 2025 Haokai Ding · Last updated 2025-09-09</p>
     </footer>
+  </div>
+
+  <!-- 视频弹窗 -->
+  <div id="videoModal" class="video-modal" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="video-modal-content">
+      <button class="close-button" id="videoClose" type="button" aria-label="Close video">&times;</button>
+      <video id="videoPlayer" src="vedios/SPIDAPT.mp4" controls></video>
+    </div>
   </div>
 
   <!-- 论文 PDF 预览弹窗（保留） -->

--- a/scripts.js
+++ b/scripts.js
@@ -24,6 +24,15 @@
     pdfClose.addEventListener('click', closePdfModal);
     document.addEventListener('click',e=>{const t=e.target.closest('.pdf-link');if(!t)return;e.preventDefault();openPdfModal(t.getAttribute('data-pdf'));});
 
+    /* 视频弹窗 */
+    const videoModal=$('#videoModal'), videoPlayer=$('#videoPlayer'), videoClose=$('#videoClose'), videoButton=$('#videoButton');
+    function openVideoModal(){lastFocused=document.activeElement;videoModal.classList.add('open');videoModal.setAttribute('aria-hidden','false');videoPlayer.play();videoClose.focus();}
+    function closeVideoModal(){videoModal.classList.remove('open');videoModal.setAttribute('aria-hidden','true');videoPlayer.pause();videoPlayer.currentTime=0;if(lastFocused&&lastFocused.focus)lastFocused.focus();}
+    if(videoButton) videoButton.addEventListener('click',openVideoModal);
+    videoClose.addEventListener('click',closeVideoModal);
+    document.addEventListener('keydown',e=>{ if(e.key==='Escape') closeVideoModal(); });
+    window.addEventListener('click',e=>{ if(e.target===videoModal) closeVideoModal(); });
+
     /* 返回顶部 */
     const backBtn=$('#backToTop');
     const onScroll=()=>{ backBtn.style.display=(window.scrollY>300)?'block':'none'; };

--- a/styles.css
+++ b/styles.css
@@ -25,6 +25,7 @@
     nav.site-nav{
       background:#f5f5f5;padding:10px 12px;border-radius:12px;margin-bottom:16px;
       display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:12px;
+      position:sticky;top:0;z-index:1000;
     }
     nav.site-nav a{
       text-decoration:none;font-family:'Lato',sans-serif;font-weight:700;color:var(--brand);
@@ -42,7 +43,8 @@
     .download-cv{
       display:inline-block;padding:6px 12px;
       background:var(--brand);color:#fff!important;border-radius:6px;
-      font-family:'Lato',sans-serif;font-weight:700;text-decoration:none
+      font-family:'Lato',sans-serif;font-weight:700;text-decoration:none;
+      border:none;cursor:pointer;
     }
     .download-cv:hover{background:#094a99;text-decoration:none}
 
@@ -83,10 +85,10 @@
     .pub-venue{font-size:1em;color:#555;font-style:italic}
 
     .pub-links{margin-top:6px;display:flex;flex-wrap:wrap;align-items:center;gap:6px 8px}
-    .pub-links > a, .pub-links > .pdf-link{
+    .pub-links > a, .pub-links > .pdf-link, .pub-links > .video-link{
       cursor:pointer;text-decoration:none;font-weight:700;font-family:'Lato',sans-serif;font-size:.92em;color:var(--brand)
     }
-    .pub-links > a:hover, .pub-links > .pdf-link:hover{ text-decoration:underline }
+    .pub-links > a:hover, .pub-links > .pdf-link:hover, .pub-links > .video-link:hover{ text-decoration:underline }
 
     /* 徽章 */
     .ei-badge,.sci-badge,.jcrq1-badge,.accepted-badge,.published-badge,.author-badge,.advisor-badge{
@@ -118,7 +120,11 @@
     body.dark-mode{background:#1a1a1a;color:#f5f5f5}
     .dark-mode h2,.dark-mode h3,.dark-mode h4,.dark-mode .pub-index,.dark-mode .pub-authors b{color:#f5f5f5}
     .dark-mode .contact-info p,.dark-mode .entry-date,.dark-mode .pub-authors,.dark-mode .pub-venue,.dark-mode .award-year{color:#aaa}
-    .dark-mode .contact-info a,.dark-mode .entry-details a,.dark-mode .pub-links > a,.dark-mode .pub-links > .pdf-link{color:#8ab4f8}
+    .dark-mode .contact-info a,
+    .dark-mode .entry-details a,
+    .dark-mode .pub-links > a,
+    .dark-mode .pub-links > .pdf-link,
+    .dark-mode .pub-links > .video-link{color:#8ab4f8}
     .dark-mode hr{background:#444}
     .dark-mode nav.site-nav{background:#2a2a2a}
     .dark-mode nav.site-nav a{color:#8ab4f8;background:#333;border-color:#444}
@@ -135,9 +141,21 @@
     html:not([data-lang="zh"]) .lang-zh{display:none!important}
     html[data-lang="zh"] .lang-en{display:none!important}
 
+    /* 视频弹窗 */
+    .video-modal{
+      position:fixed;inset:0;background:rgba(0,0,0,.7);z-index:2000;
+      opacity:0;visibility:hidden;pointer-events:none;transition:opacity .2s;
+    }
+    .video-modal.open{opacity:1;visibility:visible;pointer-events:auto;}
+    .video-modal-content{
+      position:relative;margin:5% auto;width:60%;max-width:800px;
+      background:#000;border-radius:10px;box-shadow:0 5px 15px rgba(0,0,0,.3);overflow:hidden;
+    }
+    .video-modal-content video{width:100%;height:auto;display:block;}
+
     /* PDF 预览弹窗（用于论文 PDF，保留） */
     .pdf-modal{
-      position:fixed;inset:0;background:rgba(0,0,0,.7);z-index:1000;
+      position:fixed;inset:0;background:rgba(0,0,0,.7);z-index:2000;
       opacity:0;visibility:hidden;pointer-events:none;transition:opacity .2s;
     }
     .pdf-modal.open{opacity:1;visibility:visible;pointer-events:auto;}


### PR DESCRIPTION
## Summary
- Move SPIDAPT demo link beside the IROS conference paper entry
- Keep navigation bar visible with sticky positioning and adjust styles
- Guard video modal script and restyle publication links for new demo button

## Testing
- `node --check scripts.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e3234890832fbc38d8645a72cf45