### PR TITLE
Use emoji icons for contact links

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,6 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet" />
 
-  <!-- Font Awesome for contact icons -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-X0XroBs5Guk3F7S3w7Dnk3a1JpN96CB2A+qsYqS+8CA0nVddOZXS6jttuPAHyBs+K6TfGsDz3jHK5vVsQt1YgA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
@@ -56,11 +54,11 @@
             <span class="lang-zh">清华大学钱学森班 - 深圳零一学院 (中国, 深圳)</span>
           </p>
           <ul class="contact-list">
-            <li><i class="fa-solid fa-location-dot"></i> <span class="lang-en">Canton, China</span><span class="lang-zh">中国·广州</span></li>
-            <li><a href="pdfs/HaokaiDing_CV_EN.pdf" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-file"></i> <span class="lang-en">Résumé</span><span class="lang-zh">简历</span></a></li>
-            <li><a href="https://scholar.google.com/citations?user=ikir1CUAAAAJ&hl=en" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-graduation-cap"></i> <span class="lang-en">Scholar</span><span class="lang-zh">学术</span></a></li>
-            <li><a href="mailto:hk_ding@outlook.com"><i class="fa-solid fa-envelope"></i> <span class="lang-en">Email</span><span class="lang-zh">邮箱</span></a></li>
-            <li><a href="https://github.com/hkding0125" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-github"></i> Github</a></li>
+            <li><span class="contact-icon" aria-hidden="true">📍</span> <span class="lang-en">Canton, China</span><span class="lang-zh">中国·广州</span></li>
+            <li><a href="pdfs/HaokaiDing_CV_EN.pdf" target="_blank" rel="noopener noreferrer"><span class="contact-icon" aria-hidden="true">📄</span> <span class="lang-en">Résumé</span><span class="lang-zh">简历</span></a></li>
+            <li><a href="https://scholar.google.com/citations?user=ikir1CUAAAAJ&hl=en" target="_blank" rel="noopener noreferrer"><span class="contact-icon" aria-hidden="true">🎓</span> <span class="lang-en">Scholar</span><span class="lang-zh">学术</span></a></li>
+            <li><a href="mailto:hk_ding@outlook.com"><span class="contact-icon" aria-hidden="true">✉️</span> <span class="lang-en">Email</span><span class="lang-zh">邮箱</span></a></li>
+            <li><a href="https://github.com/hkding0125" target="_blank" rel="noopener noreferrer"><span class="contact-icon" aria-hidden="true">🐙</span> Github</a></li>
           </ul>
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -40,8 +40,8 @@
     .contact-info a{color:var(--brand);text-decoration:none}
     .contact-info a:hover{text-decoration:underline}
     .contact-list{list-style:none;margin:6px 0 0 0;padding:0;font-family:'Lato',sans-serif;font-size:.95em;display:flex;flex-wrap:wrap;gap:8px}
-    .contact-list li{display:flex;align-items:center;color:#444}
-    .contact-list li i{margin-right:8px;color:#666;font-size:1.1em;width:20px;text-align:center}
+      .contact-list li{display:flex;align-items:center;color:#444}
+      .contact-list .contact-icon{margin-right:8px;color:#666;font-size:1.1em;width:20px;text-align:center}
     .contact-list li a{color:#444;text-decoration:none}
     .contact-list li a:hover{text-decoration:underline;color:var(--brand)}
     .header-info{display:flex;flex-direction:column}


### PR DESCRIPTION
## Summary
- Replace Font Awesome contact icons with lightweight emoji equivalents
- Style new icons via `.contact-icon` class and remove external Font Awesome dependency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c10e570080832fb764d684fcff5ae5