### PR TITLE
Remove duplicate Download CV button

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,9 +20,6 @@
         <a href="#" data-lang="en" class="lang-link active">English</a> /
         <a href="#" data-lang="zh" class="lang-link">中文</a>
       </div>
-      <a class="download-cv" href="pdfs/HaokaiDing_CV_EN.pdf" target="_blank" rel="noopener noreferrer">
-        <span class="lang-en">📄 Download CV</span><span class="lang-zh">📄 下载简历</span>
-      </a>
     </div>
 
     <nav class="site-nav" aria-label="Section navigation">

--- a/styles.css
+++ b/styles.css
@@ -15,7 +15,7 @@
     img{max-width:100%;height:auto;}
     .container{max-width:900px;width:100%;margin:40px 20px;}
 
-    /* 顶部控件（已移除导出 PDF 按钮）*/
+    /* 顶部控件 */
     .top-controls{display:flex;justify-content:flex-end;align-items:center;gap:8px;margin-bottom:12px;font-family:'Lato',sans-serif;font-size:.9em}
     #theme-switcher{background:none;border:none;cursor:pointer;font-size:1.4em;padding:0 5px;line-height:1}
     #lang-switcher a{color:#888;font-weight:700;text-decoration:none;padding:4px 8px;border-radius:4px;transition:all .2s}
@@ -45,14 +45,12 @@
     .contact-list li a{color:#444;text-decoration:none}
     .contact-list li a:hover{text-decoration:underline;color:var(--brand)}
     .header-info{display:flex;flex-direction:column}
-    .download-cv,
     .watch-video{
       display:inline-block;padding:6px 12px;
       background:var(--brand);color:#fff!important;border-radius:6px;
       font-family:'Lato',sans-serif;font-weight:700;text-decoration:none;
       border:none;cursor:pointer;
     }
-    .download-cv:hover,
     .watch-video:hover{background:#094a99;text-decoration:none}
 
     .profile-container{position:relative;width:120px;aspect-ratio:2/3;margin-right:30px;border-radius:10px;overflow:hidden;flex-shrink:0;box-shadow:0 0 8px rgba(0,0,0,.1)}


### PR DESCRIPTION
## Summary
- remove top-right "Download CV" link which duplicated the résumé link
- clean up CSS by deleting the unused `.download-cv` styles

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c11e7891dc832fa6c11a5c0d1d6ee6