### PR TITLE
Use buttons for language switcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,8 @@
     <div class="top-controls">
       <button id="theme-switcher" type="button" aria-label="Toggle dark mode">🌙</button>
       <div id="lang-switcher" aria-label="Language switcher">
-        <a href="#" data-lang="en" class="lang-link active">English</a> /
-        <a href="#" data-lang="zh" class="lang-link">中文</a>
+        <button data-lang="en" class="lang-link active">English</button> /
+        <button data-lang="zh" class="lang-link">中文</button>
       </div>
     </div>
 

--- a/scripts.js
+++ b/scripts.js
@@ -7,8 +7,8 @@
     themeSwitcher.addEventListener('click',()=>{const cur=document.body.classList.contains('dark-mode')?'dark':'light';const nxt=cur==='dark'?'light':'dark';localStorage.setItem('theme',nxt);applyTheme(nxt);});
 
     /* 语言切换 */
-    function setLanguage(lang){document.documentElement.setAttribute('data-lang',lang); $$('#lang-switcher .lang-link').forEach(a=>a.classList.toggle('active',a.dataset.lang===lang)); try{localStorage.setItem('preferredLanguage',lang);}catch{}}
-    $('#lang-switcher').addEventListener('click',e=>{const a=e.target.closest('.lang-link');if(!a)return;e.preventDefault();setLanguage(a.dataset.lang);});
+    function setLanguage(lang){document.documentElement.setAttribute('data-lang',lang); $$('#lang-switcher .lang-link').forEach(b=>b.classList.toggle('active',b.dataset.lang===lang)); try{localStorage.setItem('preferredLanguage',lang);}catch{}}
+    $$('#lang-switcher .lang-link').forEach(b=>b.addEventListener('click',()=>setLanguage(b.dataset.lang)));
     document.addEventListener('DOMContentLoaded',()=>setLanguage(localStorage.getItem('preferredLanguage')||'en'));
 
     /* 触摸头像切换 */

--- a/styles.css
+++ b/styles.css
@@ -18,8 +18,8 @@
     /* 顶部控件 */
     .top-controls{display:flex;justify-content:flex-end;align-items:center;gap:8px;margin-bottom:12px;font-family:'Lato',sans-serif;font-size:.9em}
     #theme-switcher{background:none;border:none;cursor:pointer;font-size:1.4em;padding:0 5px;line-height:1}
-    #lang-switcher a{color:#888;font-weight:700;text-decoration:none;padding:4px 8px;border-radius:4px;transition:all .2s}
-    #lang-switcher a.active{color:var(--brand);background:#e7f1ff}
+    #lang-switcher button{color:#888;font-weight:700;text-decoration:none;padding:4px 8px;border-radius:4px;transition:all .2s;background:none;border:none;cursor:pointer}
+    #lang-switcher button.active{color:var(--brand);background:#e7f1ff}
 
     /* 导航 */
     nav.site-nav{


### PR DESCRIPTION
## Summary
- Replace language switcher links with buttons for better semantics.
- Listen for button clicks in scripts.js instead of link clicks and remove preventDefault.
- Update CSS to style the new language switcher buttons.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c13a3fdfd4832f9904274778ea447b