### PR TITLE
style: align ORCID icon with other contact logos

### DIFF
--- a/my-academic-site/images/icons/orcid.svg
+++ b/my-academic-site/images/icons/orcid.svg
@@ -1,1 +1,6 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>ORCID</title><path d="M12 0C5.372 0 0 5.372 0 12s5.372 12 12 12 12-5.372 12-12S18.628 0 12 0zM7.369 4.378c.525 0 .947.431.947.947s-.422.947-.947.947a.95.95 0 0 1-.947-.947c0-.525.422-.947.947-.947zm-.722 3.038h1.444v10.041H6.647V7.416zm3.562 0h3.9c3.712 0 5.344 2.653 5.344 5.025 0 2.578-2.016 5.025-5.325 5.025h-3.919V7.416zm1.444 1.303v7.444h2.297c3.272 0 4.022-2.484 4.022-3.722 0-2.016-1.284-3.722-4.097-3.722h-2.222z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#666" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <line x1="9" y1="9" x2="9" y2="15"/>
+  <circle cx="9" cy="7" r="1"/>
+  <path d="M14 9h2a4 4 0 0 1 0 8h-2z"/>
+</svg>


### PR DESCRIPTION
## Summary
- replace ORCID SVG icon with line-styled version to match other contact logos

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c7f4735de8832f824b87eb4dcd2d92