### PR TITLE
Replace EI badges with RAS and IEEE labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,8 @@
               <div class="pub-links">
                 <span class="pdf-link" data-pdf="pdfs/icia_v4.pdf">[PDF]</span>
                 <span class="accepted-badge">Accepted</span>
-                <span class="ei-badge">EI</span>
+                <span class="ras-badge">RAS</span>
+                <span class="ieee-badge">IEEE</span>
               </div>
             </div>
           </li>
@@ -159,7 +160,8 @@
                   <span class="lang-en">🎥 SPIDAPT Demo</span><span class="lang-zh">🎥 SPIDAPT演示</span>
                 </button>
                 <span class="accepted-badge">Accepted</span>
-                <span class="ei-badge">EI</span>
+                <span class="ras-badge">RAS</span>
+                <span class="ieee-badge">IEEE</span>
               </div>
             </div>
           </li>
@@ -172,7 +174,8 @@
               <div class="pub-links">
                 <span class="pdf-link" data-pdf="pdfs/CASE25_0693_FI.pdf">[PDF]</span>
                 <span class="published-badge">Published</span>
-                <span class="ei-badge">EI</span>
+                <span class="ras-badge">RAS</span>
+                <span class="ieee-badge">IEEE</span>
               </div>
             </div>
           </li>
@@ -185,7 +188,8 @@
               <div class="pub-links">
                 <span class="pdf-link" data-pdf="pdfs/ICARM25_0037_FI.pdf">[PDF]</span>
                 <span class="published-badge">Published</span>
-                <span class="ei-badge">EI</span>
+                <span class="ras-badge">RAS</span>
+                <span class="ieee-badge">IEEE</span>
               </div>
             </div>
           </li>
@@ -198,7 +202,8 @@
               <div class="pub-links">
                 <span class="pdf-link" data-pdf="pdfs/e3sconf_eppc2025_02010.pdf">[PDF]</span>
                 <a href="https://doi.org/10.1051/e3sconf/202561502010" target="_blank" rel="noopener noreferrer">[DOI]</a>
-                <span class="ei-badge">EI</span>
+                <span class="ras-badge">RAS</span>
+                <span class="ieee-badge">IEEE</span>
               </div>
             </div>
           </li>

--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,6 @@
     :root{
       --brand:#0b63c7;
-      --ei-color:#1266f1; --sci-color:#2e9e44; --jcrq1-color:#6a4cc7;
+    --ras-color:#f39c12; --ieee-color:#1266f1; --sci-color:#2e9e44; --jcrq1-color:#6a4cc7;
       --accepted-color:#56606a; --published-color:#3f4954;
       --author-color:#0d6efd;           /* Co-first */
       --advisor-color:#ff9800;          /* Advisor */
@@ -96,14 +96,15 @@
     .pub-links > a:hover, .pub-links > .pdf-link:hover{ text-decoration:underline }
 
     /* 徽章 */
-    .ei-badge,.sci-badge,.jcrq1-badge,.accepted-badge,.published-badge,.author-badge,.advisor-badge{
+  .ras-badge,.ieee-badge,.sci-badge,.jcrq1-badge,.accepted-badge,.published-badge,.author-badge,.advisor-badge{
       display:inline-flex;align-items:center;justify-content:center;
       font-size:0.86em;font-weight:800;letter-spacing:.2px;
       border-radius:999px;padding:4px 10px;line-height:1.2;
       color:#fff;white-space:nowrap;vertical-align:middle;
       -webkit-print-color-adjust: exact; print-color-adjust: exact;
     }
-    .ei-badge{background:var(--ei-color)}
+  .ras-badge{background:var(--ras-color)}
+  .ieee-badge{background:var(--ieee-color)}
     .sci-badge{background:var(--sci-color)}
     .jcrq1-badge{background:var(--jcrq1-color)}
     .accepted-badge{background:var(--accepted-color)}


### PR DESCRIPTION
## Summary
- replace EI labels on conference publications with new RAS and IEEE badges
- add styling support for the new RAS and IEEE badges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d24d410d34832fbea7290ce7e07483