### PR TITLE
Add organization logos to publication badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,8 +143,8 @@
               <div class="pub-links">
                 <span class="pdf-link" data-pdf="pdfs/icia_v4.pdf">[PDF]</span>
                 <span class="accepted-badge">Accepted</span>
-                <span class="ras-badge">RAS</span>
-                <span class="ieee-badge">IEEE</span>
+                <span class="ras-badge"><img src="my-academic-site/images/icons/ras-logo.svg" alt="RAS logo" class="badge-icon">RAS</span>
+                <span class="ieee-badge"><img src="my-academic-site/images/icons/ieee-logo.svg" alt="IEEE logo" class="badge-icon">IEEE</span>
               </div>
             </div>
           </li>
@@ -160,8 +160,8 @@
                   <span class="lang-en">🎥 SPIDAPT Demo</span><span class="lang-zh">🎥 SPIDAPT演示</span>
                 </button>
                 <span class="accepted-badge">Accepted</span>
-                <span class="ras-badge">RAS</span>
-                <span class="ieee-badge">IEEE</span>
+                <span class="ras-badge"><img src="my-academic-site/images/icons/ras-logo.svg" alt="RAS logo" class="badge-icon">RAS</span>
+                <span class="ieee-badge"><img src="my-academic-site/images/icons/ieee-logo.svg" alt="IEEE logo" class="badge-icon">IEEE</span>
               </div>
             </div>
           </li>
@@ -174,8 +174,8 @@
               <div class="pub-links">
                 <span class="pdf-link" data-pdf="pdfs/CASE25_0693_FI.pdf">[PDF]</span>
                 <span class="published-badge">Published</span>
-                <span class="ras-badge">RAS</span>
-                <span class="ieee-badge">IEEE</span>
+                <span class="ras-badge"><img src="my-academic-site/images/icons/ras-logo.svg" alt="RAS logo" class="badge-icon">RAS</span>
+                <span class="ieee-badge"><img src="my-academic-site/images/icons/ieee-logo.svg" alt="IEEE logo" class="badge-icon">IEEE</span>
               </div>
             </div>
           </li>
@@ -188,8 +188,8 @@
               <div class="pub-links">
                 <span class="pdf-link" data-pdf="pdfs/ICARM25_0037_FI.pdf">[PDF]</span>
                 <span class="published-badge">Published</span>
-                <span class="ras-badge">RAS</span>
-                <span class="ieee-badge">IEEE</span>
+                <span class="ras-badge"><img src="my-academic-site/images/icons/ras-logo.svg" alt="RAS logo" class="badge-icon">RAS</span>
+                <span class="ieee-badge"><img src="my-academic-site/images/icons/ieee-logo.svg" alt="IEEE logo" class="badge-icon">IEEE</span>
               </div>
             </div>
           </li>
@@ -202,8 +202,8 @@
               <div class="pub-links">
                 <span class="pdf-link" data-pdf="pdfs/e3sconf_eppc2025_02010.pdf">[PDF]</span>
                 <a href="https://doi.org/10.1051/e3sconf/202561502010" target="_blank" rel="noopener noreferrer">[DOI]</a>
-                <span class="ras-badge">RAS</span>
-                <span class="ieee-badge">IEEE</span>
+                <span class="ras-badge"><img src="my-academic-site/images/icons/ras-logo.svg" alt="RAS logo" class="badge-icon">RAS</span>
+                <span class="ieee-badge"><img src="my-academic-site/images/icons/ieee-logo.svg" alt="IEEE logo" class="badge-icon">IEEE</span>
               </div>
             </div>
           </li>

--- a/my-academic-site/images/icons/ieee-logo.svg
+++ b/my-academic-site/images/icons/ieee-logo.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="grad" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#0f4fac"/>
+      <stop offset="100%" stop-color="#1b72d1"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="20" height="20" rx="2" ry="2" transform="rotate(45 16 16)" fill="url(#grad)"/>
+  <path d="M16 10.2l-2.4 2.4 1.2 1.2 1.2-1.2 1.2 1.2 1.2-1.2L16 10.2zm0 5l-4.2 4.2L14 23.6l2-2 2 2 2.2-4.2L16 15.2z" fill="#fff"/>
+  <text x="16" y="28" font-family="'Lato', 'Segoe UI', sans-serif" font-size="6" font-weight="700" text-anchor="middle" fill="#0f4fac">IEEE</text>
+</svg>

--- a/my-academic-site/images/icons/ras-logo.svg
+++ b/my-academic-site/images/icons/ras-logo.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="rasGradient" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#cf202e"/>
+      <stop offset="100%" stop-color="#ff5a3c"/>
+    </linearGradient>
+  </defs>
+  <circle cx="16" cy="16" r="12" fill="url(#rasGradient)"/>
+  <rect x="14.25" y="8.5" width="3.5" height="7" rx="1.75" fill="#fff"/>
+  <path d="M10 16.5c0 3.1 2.4 5.5 5.5 5.5h1c3.1 0 5.5-2.4 5.5-5.5" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="12.4" cy="12.4" r="1.1" fill="#fff"/>
+  <circle cx="19.6" cy="12.4" r="1.1" fill="#fff"/>
+  <text x="16" y="29" font-family="'Lato', 'Segoe UI', sans-serif" font-size="6" font-weight="700" text-anchor="middle" fill="#cf202e">RAS</text>
+</svg>

--- a/styles.css
+++ b/styles.css
@@ -102,7 +102,10 @@
       border-radius:999px;padding:4px 10px;line-height:1.2;
       color:#fff;white-space:nowrap;vertical-align:middle;
       -webkit-print-color-adjust: exact; print-color-adjust: exact;
+      gap:6px;
     }
+  .badge-icon{display:inline-block;width:18px;height:18px}
+  .ras-badge .badge-icon,.ieee-badge .badge-icon{filter:drop-shadow(0 0 1px rgba(0,0,0,.18))}
   .ras-badge{background:var(--ras-color)}
   .ieee-badge{background:var(--ieee-color)}
     .sci-badge{background:var(--sci-color)}


### PR DESCRIPTION
## Summary
- embed custom IEEE and RAS logo artwork and show them alongside the publication badges
- update badge styling to accommodate inline icons while maintaining layout consistency

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68d2c48b2794832fac116d90fb0ded4f