### PR TITLE
Remove RAS and IEEE badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,8 +143,6 @@
               <div class="pub-links">
                 <span class="pdf-link" data-pdf="pdfs/icia_v4.pdf">[PDF]</span>
                 <span class="accepted-badge">Accepted</span>
-                <span class="ras-badge"><img src="my-academic-site/images/icons/ras-logo.svg" alt="RAS logo" class="badge-icon">RAS</span>
-                <span class="ieee-badge"><img src="my-academic-site/images/icons/ieee-logo.svg" alt="IEEE logo" class="badge-icon">IEEE</span>
               </div>
             </div>
           </li>
@@ -160,8 +158,6 @@
                   <span class="lang-en">🎥 SPIDAPT Demo</span><span class="lang-zh">🎥 SPIDAPT演示</span>
                 </button>
                 <span class="accepted-badge">Accepted</span>
-                <span class="ras-badge"><img src="my-academic-site/images/icons/ras-logo.svg" alt="RAS logo" class="badge-icon">RAS</span>
-                <span class="ieee-badge"><img src="my-academic-site/images/icons/ieee-logo.svg" alt="IEEE logo" class="badge-icon">IEEE</span>
               </div>
             </div>
           </li>
@@ -174,8 +170,6 @@
               <div class="pub-links">
                 <span class="pdf-link" data-pdf="pdfs/CASE25_0693_FI.pdf">[PDF]</span>
                 <span class="published-badge">Published</span>
-                <span class="ras-badge"><img src="my-academic-site/images/icons/ras-logo.svg" alt="RAS logo" class="badge-icon">RAS</span>
-                <span class="ieee-badge"><img src="my-academic-site/images/icons/ieee-logo.svg" alt="IEEE logo" class="badge-icon">IEEE</span>
               </div>
             </div>
           </li>
@@ -188,8 +182,6 @@
               <div class="pub-links">
                 <span class="pdf-link" data-pdf="pdfs/ICARM25_0037_FI.pdf">[PDF]</span>
                 <span class="published-badge">Published</span>
-                <span class="ras-badge"><img src="my-academic-site/images/icons/ras-logo.svg" alt="RAS logo" class="badge-icon">RAS</span>
-                <span class="ieee-badge"><img src="my-academic-site/images/icons/ieee-logo.svg" alt="IEEE logo" class="badge-icon">IEEE</span>
               </div>
             </div>
           </li>
@@ -202,8 +194,6 @@
               <div class="pub-links">
                 <span class="pdf-link" data-pdf="pdfs/e3sconf_eppc2025_02010.pdf">[PDF]</span>
                 <a href="https://doi.org/10.1051/e3sconf/202561502010" target="_blank" rel="noopener noreferrer">[DOI]</a>
-                <span class="ras-badge"><img src="my-academic-site/images/icons/ras-logo.svg" alt="RAS logo" class="badge-icon">RAS</span>
-                <span class="ieee-badge"><img src="my-academic-site/images/icons/ieee-logo.svg" alt="IEEE logo" class="badge-icon">IEEE</span>
               </div>
             </div>
           </li>

--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,6 @@
     :root{
       --brand:#0b63c7;
-    --ras-color:#f39c12; --ieee-color:#1266f1; --sci-color:#2e9e44; --jcrq1-color:#6a4cc7;
+    --sci-color:#2e9e44; --jcrq1-color:#6a4cc7;
       --accepted-color:#56606a; --published-color:#3f4954;
       --author-color:#0d6efd;           /* Co-first */
       --advisor-color:#ff9800;          /* Advisor */
@@ -96,27 +96,13 @@
     .pub-links > a:hover, .pub-links > .pdf-link:hover{ text-decoration:underline }
 
     /* 徽章 */
-  .ras-badge,.ieee-badge,.sci-badge,.jcrq1-badge,.accepted-badge,.published-badge,.author-badge,.advisor-badge{
+  .sci-badge,.jcrq1-badge,.accepted-badge,.published-badge,.author-badge,.advisor-badge{
       display:inline-flex;align-items:center;justify-content:center;
       font-size:0.86em;font-weight:800;letter-spacing:.2px;
       border-radius:999px;padding:4px 10px;line-height:1.2;
       color:#fff;white-space:nowrap;vertical-align:middle;
       -webkit-print-color-adjust: exact; print-color-adjust: exact;
       gap:6px;
-    }
-  .badge-icon{display:inline-block;width:18px;height:18px}
-  .ras-badge .badge-icon,.ieee-badge .badge-icon{filter:drop-shadow(0 0 1px rgba(0,0,0,.18))}
-  .ras-badge{background:var(--ras-color)}
-  .ieee-badge{
-      background:linear-gradient(135deg,#0b5ed7,#1a7bff);
-      box-shadow:0 4px 10px rgba(18,102,241,.28);
-      border:1px solid rgba(255,255,255,.35);
-      text-transform:uppercase;
-      letter-spacing:.35px;
-      padding:5px 14px;
-    }
-  .ieee-badge .badge-icon{
-      width:20px;height:20px;flex-shrink:0;
     }
     .sci-badge{background:var(--sci-color)}
     .jcrq1-badge{background:var(--jcrq1-color)}


### PR DESCRIPTION
## Summary
- remove the RAS and IEEE badges from each publication entry in the publications list
- simplify badge styling variables and rules now that the RAS and IEEE badges are gone

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d2cc78f6b8832fa6726007621cb8e0