### PR TITLE
Add DOI link for CASE 2025 conference paper

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,6 +170,7 @@
               <div class="pub-venue">Proceedings of the 2025 IEEE International Conference on Automation Science and Engineering (CASE)</div>
               <div class="pub-links">
                 <span class="pdf-link" data-pdf="pdfs/CASE25_0693_FI.pdf">[PDF]</span>
+                <a href="https://doi.org/10.1109/case58245.2025.11163785" target="_blank" rel="noopener noreferrer">[DOI]</a>
                 <span class="published-badge">Published</span>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add the DOI link to the 2025 IEEE CASE conference paper entry on the publications list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc9b21979c832fa98a66edf331a218