### PR TITLE
Remove redundant published badge for CASE paper

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,6 @@
               <div class="pub-links">
                 <span class="pdf-link" data-pdf="pdfs/CASE25_0693_FI.pdf">[PDF]</span>
                 <a href="https://doi.org/10.1109/case58245.2025.11163785" target="_blank" rel="noopener noreferrer">[DOI]</a>
-                <span class="published-badge">Published</span>
               </div>
             </div>
           </li>


### PR DESCRIPTION
## Summary
- remove the Published badge from the CASE 2025 conference paper entry now that the DOI link is present

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68dc9d72e0fc832fa6bcaea519268e6f