### PR TITLE
Add ROBIO 2025 conference paper entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,6 +136,17 @@
         <h4><span class="lang-en">Conference Papers</span><span class="lang-zh">会议论文</span></h4>
         <ul class="publication-list">
           <li class="publication-item">
+            <div class="pub-index">[C6]</div>
+            <div class="pub-details">
+              <div class="pub-title">BioCrest - A Flexible Adaptive Robotic Hand Based on Idle-Stroke Mechanism</div>
+              <div class="pub-authors"><b>Haokai Ding<sup>†</sup></b>, Xianjie Zhong<sup>†</sup>, Wenke Huang, Wenzeng Zhang, Tao Yang</div>
+              <div class="pub-venue">Proceedings of the 2025 IEEE International Conference on Robotics and Biomimetics (ROBIO)</div>
+              <div class="pub-links">
+                <span class="accepted-badge">Accepted</span>
+              </div>
+            </div>
+          </li>
+          <li class="publication-item">
             <div class="pub-index">[C5]</div>
             <div class="pub-details">
               <div class="pub-title">An Underactuated Gripper with Grasshopper-Inspired Linkages and Delay Triggering for Pinching and Adaptive Grasping</div>


### PR DESCRIPTION
## Summary
- add the newly accepted ROBIO 2025 paper "BioCrest - A Flexible Adaptive Robotic Hand Based on Idle-Stroke Mechanism" to the publications list

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dccc9d0e48832f9e1dd1446e4312f1