### PR TITLE
Restore BioCrest co-author list

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
             <div class="pub-index">[C6]</div>
             <div class="pub-details">
               <div class="pub-title">BioCrest - A Flexible Adaptive Robotic Hand Based on Idle-Stroke Mechanism</div>
-              <div class="pub-authors"><b>Haokai Ding</b></div>
+              <div class="pub-authors"><b>Haokai Ding</b>, X.Zhong, W.Huang, W.Zhang, T.Yang</div>
               <div class="pub-venue">Proceedings of the 2025 IEEE International Conference on Robotics and Biomimetics (ROBIO)</div>
               <div class="pub-links">
                 <span class="pdf-link" data-pdf="pdfs/428.pdf">[PDF]</span>


### PR DESCRIPTION
## Summary
- restore the full BioCrest conference paper author list while keeping Haokai Ding as sole first author

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd99da214832f8dfdc7bcdbf10fb2