### PR TITLE
Mark corresponding authors for BioCrest paper

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
             <div class="pub-index">[C6]</div>
             <div class="pub-details">
               <div class="pub-title">BioCrest - A Flexible Adaptive Robotic Hand Based on Idle-Stroke Mechanism</div>
-              <div class="pub-authors"><b>Haokai Ding</b>, X.Zhong, W.Huang, W.Zhang, T.Yang</div>
+              <div class="pub-authors"><b>Haokai Ding</b>, X.Zhong, W.Huang, W.Zhang*, T.Yang*</div>
               <div class="pub-venue">Proceedings of the 2025 IEEE International Conference on Robotics and Biomimetics (ROBIO)</div>
               <div class="pub-links">
                 <span class="pdf-link" data-pdf="pdfs/428.pdf">[PDF]</span>


### PR DESCRIPTION
## Summary
- mark W.Zhang and T.Yang as corresponding authors on the BioCrest conference entry

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dcdc96cb24832fa904062bc6a3624d