### PR TITLE
Add visitor IP-based map to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,12 @@
   <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet" />
 
   <link rel="stylesheet" href="styles.css" />
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+    crossorigin=""
+  />
 </head>
 <body>
   <div class="container">
@@ -283,6 +289,19 @@
           <div class="award-item"><span class="award-name"><span class="lang-en">Outstanding Student Cadre Award</span><span class="lang-zh">深圳技术大学“优秀学生干部”</span></span><span class="award-year">2024</span></div>
         </div>
       </section>
+
+      <section id="visitor-map" class="page-avoid">
+        <h2><span class="lang-en">Visitor Map</span><span class="lang-zh">访问地图</span></h2><hr>
+        <p class="map-description">
+          <span class="lang-en">See an approximate location of your visit based on your IP address.</span>
+          <span class="lang-zh">基于您的 IP 地址，展示您此次访问的大致位置。</span>
+        </p>
+        <div id="visitorMap" role="img" aria-label="Visitor location map"></div>
+        <p id="visitorMapStatus" class="map-note" aria-live="polite">
+          <span class="lang-en">Loading your approximate location…</span>
+          <span class="lang-zh">正在加载您的大致位置…</span>
+        </p>
+      </section>
     </main>
 
     <footer>
@@ -309,6 +328,11 @@
   <!-- 返回顶部 -->
   <button id="backToTop" type="button" aria-label="Back to top">⬆️</button>
 
+  <script
+    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha256-o9N1j7kPpGt3JSrS2JbEo4JbUdw0LFpbbQbbH2yZu3A="
+    crossorigin=""
+  ></script>
   <script src="scripts.js"></script>
 </body>
 </html>

--- a/scripts.js
+++ b/scripts.js
@@ -80,3 +80,41 @@
       target.textContent=`${parsed.getFullYear()}-${pad(parsed.getMonth()+1)}-${pad(parsed.getDate())}`;
     });
 
+    /* 访问地图 */
+    document.addEventListener('DOMContentLoaded', ()=>{
+      const mapContainer=document.getElementById('visitorMap');
+      if(!mapContainer || typeof L==='undefined') return;
+      const statusEl=document.getElementById('visitorMapStatus');
+      const setStatus=(en,zh)=>{
+        if(!statusEl) return;
+        statusEl.innerHTML=`<span class="lang-en">${en}</span><span class="lang-zh">${zh}</span>`;
+      };
+      const map=L.map(mapContainer,{worldCopyJump:true}).setView([20,0],2);
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{
+        maxZoom:18,
+        attribution:'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+      }).addTo(map);
+      setStatus('Locating your approximate position…','正在定位您的大致位置…');
+      fetch('https://ipapi.co/json/')
+        .then(res=>res.ok?res.json():Promise.reject(new Error('Network response was not ok')))
+        .then(data=>{
+          if(!data || typeof data.latitude==='undefined' || typeof data.longitude==='undefined'){
+            throw new Error('Missing coordinates');
+          }
+          const lat=Number.parseFloat(data.latitude);
+          const lon=Number.parseFloat(data.longitude);
+          if(Number.isNaN(lat) || Number.isNaN(lon)) throw new Error('Invalid coordinates');
+          const locationParts=[data.city,data.region,data.country_name].filter(Boolean);
+          const locationText=locationParts.join(', ')||'Unknown location';
+          map.setView([lat,lon],6);
+          L.marker([lat,lon]).addTo(map).bindPopup(locationText).openPopup();
+          setStatus(
+            `Approximate location based on your IP: ${locationText}.`,
+            `基于您的 IP 推测的大致位置：${locationText}。`
+          );
+        })
+        .catch(()=>{
+          setStatus('Unable to locate your position automatically.','无法自动定位您的位置。');
+        });
+    });
+

--- a/styles.css
+++ b/styles.css
@@ -67,6 +67,26 @@
     h4{font-size:1.05em;color:#444;margin:20px 0 15px}
     hr{border:0;height:1px;background:#e5e5e5;margin:8px 0 18px}
 
+    /* 访问地图 */
+    #visitorMap{
+      height:320px;
+      border-radius:14px;
+      border:1px solid #e0e0e0;
+      overflow:hidden;
+      margin-top:12px;
+    }
+    .map-description{font-size:.95em;color:#555;margin:6px 0 0}
+    .map-note{
+      font-size:.9em;
+      color:#666;
+      margin:10px 0 0;
+      font-family:'Lato',sans-serif;
+    }
+
+    body.dark-mode #visitorMap{border-color:#333}
+    body.dark-mode .map-description{color:#ccc}
+    body.dark-mode .map-note{color:#bbb}
+
     /* 主体链接可读性 */
     .main-content a{
       color:var(--brand);


### PR DESCRIPTION
## Summary
- add a bilingual visitor map section to the homepage and load Leaflet assets
- style the new map container for light and dark themes
- fetch the visitor's IP-based location and render it on the map with graceful fallbacks

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de2f8740f0832f874ce4eb757c7eaa