### PR TITLE
Fix ClustrMaps visitor map embed

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,8 +294,14 @@
           id="visitorMap"
           role="img"
           aria-label="Global visitor distribution map"
-          data-clustrmaps-id="9qN2NjdFY42ywYwkeXnJlw"
         >
+          <script
+            id="clustrmaps"
+            type="text/javascript"
+            async
+            crossorigin="anonymous"
+            src="https://clustrmaps.com/map_v2.js?cl=ffffff&w=a&t=tt&d=9qN2NjdFY42ywYwkeXnJlw&co=1d5da7&cmo=f8bd19&cmn=c62828&ct=ffffff"
+          ></script>
           <noscript>
             <p class="map-note">
               <span class="lang-en">

--- a/scripts.js
+++ b/scripts.js
@@ -84,30 +84,13 @@
     document.addEventListener('DOMContentLoaded', ()=>{
       const mapContainer=document.getElementById('visitorMap');
       if(!mapContainer) return;
-      const clustrId=mapContainer.getAttribute('data-clustrmaps-id');
-      if(!clustrId){
-        mapContainer.innerHTML=`<p class="map-note"><span class="lang-en">Visitor map unavailable.</span><span class="lang-zh">访问地图暂不可用。</span></p>`;
+      const embed=document.getElementById('clustrmaps');
+      if(!embed){
+        mapContainer.insertAdjacentHTML('beforeend', `<p class="map-note"><span class="lang-en">Visitor map unavailable.</span><span class="lang-zh">访问地图暂不可用。</span></p>`);
         return;
       }
-      const params=new URLSearchParams({
-        cl:'ffffff',
-        w:'a',
-        t:'tt',
-        d:clustrId,
-        co:'1d5da7',
-        cmo:'f8bd19',
-        cmn:'c62828',
-        ct:'ffffff'
-      });
-      const script=document.createElement('script');
-      script.id='clustrmaps';
-      script.type='text/javascript';
-      script.async=true;
-      script.src=`https://clustrmaps.com/map_v2.js?${params.toString()}`;
-      script.onerror=()=>{
+      embed.addEventListener('error', ()=>{
         mapContainer.innerHTML=`<p class="map-note"><span class="lang-en">Failed to load visitor map from ClustrMaps.</span><span class="lang-zh">无法从 ClustrMaps 加载访问地图。</span></p>`;
-      };
-      mapContainer.innerHTML='';
-      mapContainer.appendChild(script);
+      });
     });
 


### PR DESCRIPTION
## Summary
- embed the ClustrMaps script directly in the Visitor Map section so the widget initializes reliably
- simplify the Visitor Map loader script to hook into the embedded script and keep the existing fallback messaging

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68de3668af30832fa5c6cbc7f04f3c7f