### PR TITLE
Integrate ClustrMaps visitor widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,25 +293,38 @@
         <div
           id="visitorMap"
           role="img"
+          aria-live="polite"
           aria-label="Global visitor distribution map"
+          data-clustrmaps-id="aGtkaW5nMDEyNS5naXRodWIuaW8"
         >
-          <iframe
-            title="OpenStreetMap world visitor view"
-            loading="lazy"
-            referrerpolicy="no-referrer-when-downgrade"
-            src="https://www.openstreetmap.org/export/embed.html?bbox=-179.99,-85,179.99,85&layer=mapnik"
-          ></iframe>
+          <div class="map-status" id="visitorMapStatus">
+            <span class="lang-en">Loading visitor footprint…</span>
+            <span class="lang-zh">正在载入访客足迹…</span>
+          </div>
+          <noscript>
+            <p class="map-fallback">
+              <span class="lang-en">
+                JavaScript is required to display the interactive visitor map. You can view the public
+                dashboard directly on <a href="https://clustrmaps.com/site/aGtkaW5nMDEyNS5naXRodWIuaW8" target="_blank" rel="noopener noreferrer">ClustrMaps</a>.
+              </span>
+              <span class="lang-zh">
+                该交互式访客地图需要启用 JavaScript，可直接在
+                <a href="https://clustrmaps.com/site/aGtkaW5nMDEyNS5naXRodWIuaW8" target="_blank" rel="noopener noreferrer">ClustrMaps 仪表盘</a>
+                查看。
+              </span>
+            </p>
+          </noscript>
         </div>
         <p class="map-note">
           <span class="lang-en">
-            Map tiles by <a href="https://www.openstreetmap.org/" target="_blank" rel="noopener noreferrer">OpenStreetMap contributors</a>.
-            If the map fails to load, open it directly via
-            <a href="https://www.openstreetmap.org/#map=2/0.0/0.0" target="_blank" rel="noopener noreferrer">this link</a>.
+            Visitor footprint powered by <a href="https://clustrmaps.com/" target="_blank" rel="noopener noreferrer">ClustrMaps</a>.
+            If the widget does not appear, open the public dashboard directly via
+            <a href="https://clustrmaps.com/site/aGtkaW5nMDEyNS5naXRodWIuaW8" target="_blank" rel="noopener noreferrer">this link</a>.
           </span>
           <span class="lang-zh">
-            地图瓦片由 <a href="https://www.openstreetmap.org/" target="_blank" rel="noopener noreferrer">OpenStreetMap 贡献者</a> 提供。
-            若地图未能加载，可直接访问
-            <a href="https://www.openstreetmap.org/#map=2/0.0/0.0" target="_blank" rel="noopener noreferrer">该链接</a>。
+            访客足迹由 <a href="https://clustrmaps.com/" target="_blank" rel="noopener noreferrer">ClustrMaps</a> 提供。
+            若小部件未显示，可直接访问
+            <a href="https://clustrmaps.com/site/aGtkaW5nMDEyNS5naXRodWIuaW8" target="_blank" rel="noopener noreferrer">ClustrMaps 仪表盘</a>。
           </span>
         </p>
       </section>

--- a/scripts.js
+++ b/scripts.js
@@ -79,3 +79,49 @@
       const pad=n=>String(n).padStart(2,'0');
       target.textContent=`${parsed.getFullYear()}-${pad(parsed.getMonth()+1)}-${pad(parsed.getDate())}`;
     });
+
+    /* ClustrMaps 访客地图 */
+    document.addEventListener('DOMContentLoaded', ()=>{
+      const container=document.getElementById('visitorMap');
+      if(!container) return;
+      const status=document.getElementById('visitorMapStatus');
+      const id=(container.getAttribute('data-clustrmaps-id')||'').trim();
+      if(!id){
+        container.classList.add('map-error');
+        if(status){
+          status.querySelector('.lang-en').textContent='ClustrMaps identifier missing. Please configure data-clustrmaps-id.';
+          status.querySelector('.lang-zh').textContent='缺少 ClustrMaps 标识符，请配置 data-clustrmaps-id 属性。';
+        }
+        return;
+      }
+
+      const script=document.createElement('script');
+      script.async=true;
+      script.src=`https://www.clustrmaps.com/map_v2.js?cl=ffffff&w=a&t=tt&d=${encodeURIComponent(id)}`;
+      script.referrerPolicy='no-referrer-when-downgrade';
+
+      let resolved=false;
+      const clearStatus=success=>{
+        if(resolved) return;
+        resolved=true;
+        if(success){
+          container.classList.add('map-ready');
+          if(status) status.remove();
+        }else{
+          container.classList.add('map-error');
+          if(status){
+            const en=status.querySelector('.lang-en');
+            const zh=status.querySelector('.lang-zh');
+            if(en) en.textContent='Unable to load ClustrMaps widget. Please use the direct link below.';
+            if(zh) zh.textContent='ClustrMaps 小部件加载失败，请使用下方链接直接查看。';
+          }
+        }
+      };
+
+      const timeout=setTimeout(()=>clearStatus(false),12000);
+      script.addEventListener('load',()=>{clearTimeout(timeout);clearStatus(true);});
+      script.addEventListener('error',()=>{clearTimeout(timeout);clearStatus(false);});
+
+      if(status) status.insertAdjacentElement('afterend', script);
+      else container.appendChild(script);
+    });

--- a/styles.css
+++ b/styles.css
@@ -77,12 +77,43 @@
       position:relative;
       min-height:320px;
       aspect-ratio:16/9;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      padding:12px;
+      box-sizing:border-box;
     }
-    #visitorMap iframe{
-      width:100%;
-      height:100%;
-      border:0;
+    #visitorMap.map-ready{
       display:block;
+      padding:0;
+    }
+    #visitorMap iframe,
+    #visitorMap canvas,
+    #visitorMap .clustrmaps-container,
+    #visitorMap .clustrmaps-map,
+    #visitorMap .clustrmaps-widget{
+      width:100% !important;
+      height:100% !important;
+      border:0 !important;
+      display:block !important;
+    }
+    #visitorMap .map-status{
+      font-size:.95em;
+      color:#666;
+      text-align:center;
+      display:flex;
+      flex-direction:column;
+      gap:6px;
+    }
+    #visitorMap.map-error{
+      border-style:dashed;
+    }
+    #visitorMap.map-error .map-status{
+      color:#b50000;
+    }
+    .map-fallback{
+      font-size:.9em;
+      margin:8px 0 0;
     }
     .map-description{font-size:.95em;color:#555;margin:6px 0 0}
     .map-note{
@@ -93,6 +124,8 @@
     }
 
     body.dark-mode #visitorMap{border-color:#333;background:#1f1f1f}
+    body.dark-mode #visitorMap .map-status{color:#ccc}
+    body.dark-mode #visitorMap.map-error .map-status{color:#ff9f9f}
     body.dark-mode .map-description{color:#ccc}
     body.dark-mode .map-note{color:#bbb}
 


### PR DESCRIPTION
## Summary
- replace the placeholder OpenStreetMap iframe with a configurable ClustrMaps widget container and bilingual fallbacks
- load the ClustrMaps script dynamically with status messaging and error handling in scripts.js
- refresh visitor map styling for loading/error states and ensure the widget fills the container in both themes

## Testing
- python3 -m http.server 8000 (manual verification)

------
https://chatgpt.com/codex/tasks/task_e_68de3dc98608832f8861ef72487c0eed