### PR TITLE
style: adopt xzhang-inspired minimal visual theme

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -608,3 +608,96 @@ body.dark-mode .visitor-map img,body.dark-mode .visitor-map iframe{box-shadow:0 
 @media (max-width:400px){
   nav.site-nav{grid-template-columns:1fr;}
 }
+
+/* ===== XZhang-inspired minimal console style ===== */
+:root{
+  --font-sans:'JetBrains Mono','IBM Plex Mono','SFMono-Regular','Menlo','Consolas','Liberation Mono',monospace;
+  --font-nav:var(--font-sans);
+  --surface:#f6f7f9;
+  --surface-raised:transparent;
+  --border:#d8dde6;
+  --text-primary:#1f2430;
+  --text-secondary:#2c3443;
+  --text-tertiary:#5f6876;
+  --brand:#2f5da8;
+  --brand-light:#dbe8ff;
+  --radius:0;
+  --shadow-sm:none;
+  --shadow-md:none;
+}
+
+body{background:var(--surface);line-height:1.75;}
+.container{width:min(100%,860px);padding:22px 24px 34px;}
+
+nav.site-nav{
+  position:static;
+  padding:0 0 12px;
+  margin-bottom:22px;
+  border-bottom:1px dashed var(--border);
+  background:transparent;
+  backdrop-filter:none;
+  -webkit-backdrop-filter:none;
+}
+
+.header-info h1{
+  font-size:1.7em;
+  letter-spacing:0;
+  text-transform:none;
+}
+
+h2::before{width:8px;height:8px;border-radius:50%;}
+hr{margin:6px 0 14px;border-top:1px dashed var(--border);background:transparent;height:0;}
+
+.profile-container,
+.contact-list li,
+.publication-item,
+.award-item,
+.research-tags span,
+.pub-stats,
+.video-modal-content,
+.pdf-modal-content,
+#backToTop,
+.visitor-map img,
+.visitor-map iframe{
+  border-radius:0;
+  box-shadow:none;
+}
+
+.profile-container{outline:1px dashed var(--border);border:1px solid var(--border);}
+.contact-list li{
+  background:transparent;
+  border:1px dashed var(--border);
+  padding:4px 10px 4px 8px;
+}
+
+.news-item{
+  border-left:1px dashed var(--border);
+  padding:10px 0 10px 18px;
+}
+.news-item::before{box-shadow:none;}
+
+.publication-item,
+.award-item,
+.pub-stats{
+  border:1px dashed var(--border);
+  background:transparent;
+}
+.publication-item:hover,
+.award-item:hover{background:rgba(47,93,168,.04);}
+
+footer{border-top:1px dashed var(--border);}
+
+body.dark-mode{
+  --surface:#11141b;
+  --surface-raised:transparent;
+  --border:#3a4455;
+  --text-primary:#e7ebf2;
+  --text-secondary:#c3cbda;
+  --text-tertiary:#8e99ad;
+  --brand:#8eb3ff;
+  --brand-light:rgba(142,179,255,.2);
+}
+body.dark-mode nav.site-nav{background:transparent;border-bottom:1px dashed var(--border);}
+body.dark-mode hr{border-top:1px dashed var(--border);}
+body.dark-mode .publication-item:hover,
+body.dark-mode .award-item:hover{background:rgba(142,179,255,.08);}


### PR DESCRIPTION
### Motivation
- Create a compact, console/minimal visual variant inspired by `xzhang.dev` to give the site a mono-first, low-ornament aesthetic while keeping existing markup unchanged.

### Description
- Append an `XZhang-inspired minimal console style` override block to `styles.css` that switches to a monospace-first type stack and narrows the global container.
- Replace rounded cards/shadows with flat surfaces and dashed separators, and remove rounded corners on key UI elements to achieve a minimal console look.
- Make layout/tone edits for consistency: static nav, compact heading scale, tighter paddings, dashed borders around timeline/news/publication items, and transparent/flat card backgrounds.
- Adjust dark-mode variables and hover states to preserve readability under the simplified style.

### Testing
- Verified CSS brace balance using `python - <<'PY' ...` which reported matching opening/closing brace counts (`291` / `291`).
- Confirmed the change is CSS-only and applies site-wide because `index.html` and `publications.html` share `styles.css`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c55031a69c8331b74e0b267bfaa04d)